### PR TITLE
Visualizar nombre del evento en django admin

### DIFF
--- a/eventos/models.py
+++ b/eventos/models.py
@@ -8,3 +8,6 @@ class Evento(models.Model):
     fecha_fin = models.DateField()
     cupo = models.IntegerField(validators=[MinValueValidator(1)])
     lugar = models.CharField(max_length=255)
+
+    def __str__(self):
+        return "%s" % self.nombre


### PR DESCRIPTION
Se agregó el nombre del evento en la lista de eventos de django admin para identificarlo más rápido, en lugar de mostrar Object(1)